### PR TITLE
Support different gnomad files for mutect2 and pileup

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,12 +27,12 @@ It has the following steps:
 
 Run it from GitHub as follows:
 ```
-nextflow run tron-bioinformatics/tronflow-mutect2 -r v1.4.0 -profile conda --input_files $input --reference $reference --gnomad $gnomad
+nextflow run tron-bioinformatics/tronflow-mutect2 -r v1.4.0 -profile conda --input_files $input --reference $reference --mutect2_gnomad $gnomad_afonly --pileup_gnomad $gnomad_smallexac
 ```
 
 Otherwise download the project and run as follows:
 ```
-nextflow main.nf -profile conda --input_files $input --reference $reference --gnomad $gnomad
+nextflow main.nf -profile conda --input_files $input --reference $reference --mutect2_gnomad $gnomad_afonly --pileup_gnomad $gnomad_smallexac
 ```
 
 Find the help as follows:
@@ -56,8 +56,8 @@ Optional input:
     * input_name: sample name (alternative to --input_files)
     * input_tumor_bam: comma separated list of tumor BAMs (alternative to --input_files)
     * input_normal_bam: comma separated list of normal BAMs (alternative to --input_files)
-    * gnomad: path to the gnomad VCF or other germline resource (recommended). If not provided the contamination will 
-    not be estimated and the filter of common germline variants will be disabled
+    * mutect2_gnomad: path to gnomad AF only or other germline resource (recommended). If not provided, the filter of common germline variants will be disabled.
+    * pileup_gnomad: path to small exac gnomad VCF to estimate the contamination (recommended)
     * intervals: path to a BED file containing the regions to analyse
     * output: the folder where to publish output (default: output)
     * enable_bam_output: outputs a new BAM file with the Mutect2 reassembly of reads (default: false)

--- a/main.nf
+++ b/main.nf
@@ -15,7 +15,8 @@ params.input_name = false
 params.input_tumor_bam = false
 params.input_normal_bam = false
 params.reference = false
-params.gnomad = false
+params.mutect2_gnomad = false
+params.pileup_gnomad = false
 params.output = 'output'
 params.funcotator = false
 
@@ -52,7 +53,7 @@ workflow {
     MUTECT2(input_files)
     LEARN_READ_ORIENTATION_MODEL(MUTECT2.out.f1r2_stats)
 
-    if (params.gnomad) {
+    if (params.pileup_gnomad) {
         PILEUP_SUMMARIES(input_files)
         CALCULATE_CONTAMINATION(PILEUP_SUMMARIES.out.pileupsummaries)
         FILTER_CALLS(

--- a/modules/01_mutect2.nf
+++ b/modules/01_mutect2.nf
@@ -1,6 +1,6 @@
 params.memory_mutect2 = "16g"
 params.output = 'output'
-params.gnomad = false
+params.mutect2_gnomad = false
 params.pon = false
 params.disable_common_germline_filter = false
 params.reference = false
@@ -27,7 +27,7 @@ process MUTECT2 {
 
     script:
     normal_panel_option = params.pon ? "--panel-of-normals ${params.pon}" : ""
-    germline_filter = params.disable_common_germline_filter || ! params.gnomad ? "" : "--germline-resource ${params.gnomad}"
+    germline_filter = params.disable_common_germline_filter || ! params.mutect2_gnomad ? "" : "--germline-resource ${params.mutect2_gnomad}"
     normal_inputs = normal_bam.split(",").collect({v -> "--input $v"}).join(" ")
     tumor_inputs = tumor_bam.split(",").collect({v -> "--input $v"}).join(" ")
     normalRGSMs = normal_bam.split(",").collect({v -> "\$(samtools view -H $v | grep -oP '(?<=SM:)[^ |\\t]*' | head -1)"})

--- a/modules/03_pileup_summary.nf
+++ b/modules/03_pileup_summary.nf
@@ -1,6 +1,6 @@
 params.memory_pileup = "32g"
 params.output = 'output'
-params.gnomad = false
+params.pileup_gnomad = false
 
 
 process PILEUP_SUMMARIES {
@@ -21,8 +21,8 @@ process PILEUP_SUMMARIES {
     tumor_inputs = tumor_bam.split(",").collect({v -> "--input $v"}).join(" ")
     """
     gatk --java-options '-Xmx${params.memory_pileup}' GetPileupSummaries  \
-    --intervals ${params.gnomad} \
-    --variant ${params.gnomad} \
+    --intervals ${params.pileup_gnomad} \
+    --variant ${params.pileup_gnomad} \
     ${tumor_inputs} \
     --output ${name}.pileupsummaries.table
     """


### PR DESCRIPTION
* Separate gnomad files for germline filtering in MUTECT2 (gnomad_af_only_hg38) and contamination estimation in PILEUP_SUMMARIES (small_exac_common_3) to avoid Java heap out of memory error